### PR TITLE
Fix Calculator-v1 not showing results for single line operations

### DIFF
--- a/Calculator.html
+++ b/Calculator.html
@@ -53,7 +53,7 @@
 					switch (type) {
 						case "number":
 						case "boolean":
-                        case "decimal":
+						case "decimal":
 							output.text(result);
 							break;
 						case "function":

--- a/Calculator.html
+++ b/Calculator.html
@@ -53,6 +53,7 @@
 					switch (type) {
 						case "number":
 						case "boolean":
+                        case "decimal":
 							output.text(result);
 							break;
 						case "function":


### PR DESCRIPTION
Turns out that math.js v11.1.0 added `decimal` as a number type, this persisted until v13.0.0 and calculator-v1 didn't handle this at all