### PR TITLE
Add signatures(function)

### DIFF
--- a/Calculator-v2.html
+++ b/Calculator-v2.html
@@ -345,7 +345,8 @@
 
 				// Extra functions
 				math.import({
-					divmod: (x, n) => math.matrix([Math.floor(x / n), x % n])
+					divmod: (x, n) => math.matrix([Math.floor(x / n), x % n]),
+					signatures: (f) => f.signatures,
 				});
 
 				let lineResults = [];

--- a/Calculator.html
+++ b/Calculator.html
@@ -32,6 +32,12 @@
 				precision: 32
 			});
 
+			// Extra functions
+			math.import({
+				divmod: (x, n) => math.matrix([Math.floor(x / n), x % n]),
+				signatures: (f) => f.signatures,
+			});
+
 			$(function() {
 				var output = $(".output");
 				var input = $(".input");


### PR DESCRIPTION
This allows creating very generic higher-order functions. Example:

Here's a toy example:
```
applyFn(f, x)= signatures(f)["any"]!={}.u ? f(x) : signatures(f)[""]!={}.u ? f() : []["Incompatible function"];

arr=[_(x)= x+1, _()= 7]
map(arr, _(x)= applyFn(x, 3)) # [4, 7]
```

The real utility is for helper functions, e.g. `fold(array, function)` where the function might want access to array indices but does not always.

(Prior to the math.js update, you could use `clone(function).signatures` but apparently that was a bug.)